### PR TITLE
Add LabelExtracter interface

### DIFF
--- a/injectproxy/alerts_test.go
+++ b/injectproxy/alerts_test.go
@@ -65,7 +65,8 @@ func TestGetAlerts(t *testing.T) {
 		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", tc.queryParam, tc.expQueryValues...))
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel))
+
+			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -37,12 +37,10 @@ const (
 )
 
 type routes struct {
-	upstream   *url.URL
-	handler    http.Handler
-	label      string
-	labelValue string
-	headerName string
-	queryParam string
+	upstream *url.URL
+	handler  http.Handler
+	label    string
+	el       ExtractLabeler
 
 	mux            http.Handler
 	modifiers      map[string]func(*http.Response) error
@@ -50,9 +48,6 @@ type routes struct {
 }
 
 type options struct {
-	labelValue       string
-	headerName       string
-	queryParam       string
 	enableLabelAPIs  bool
 	passthroughPaths []string
 	errorOnReplace   bool
@@ -100,32 +95,10 @@ func WithErrorOnReplace() Option {
 	})
 }
 
-// WithLabelValue enforces a specific value for the multi-tenancy label.
-// If not specified, the value has to be provided as a URL parameter.
-func WithLabelValue(value string) Option {
-	return optionFunc(func(o *options) {
-		o.labelValue = value
-	})
-}
-
 // mux abstracts away the behavior we expect from the http.ServeMux type in this package.
 type mux interface {
 	http.Handler
 	Handle(string, http.Handler)
-}
-
-// WithQueryParam define the GET param where the tenant is defined
-func WithQueryParam(value string) Option {
-	return optionFunc(func(o *options) {
-		o.queryParam = value
-	})
-}
-
-// WithHeaderName define the HTTP header where the tenant is defined
-func WithHeaderName(value string) Option {
-	return optionFunc(func(o *options) {
-		o.headerName = value
-	})
 }
 
 // strictMux is a mux that wraps standard HTTP handler with safer handler that allows safe user provided handler registrations.
@@ -188,14 +161,108 @@ func (i *instrumentedMux) Handle(pattern string, handler http.Handler) {
 	i.mux.Handle(pattern, i.i.NewHandler(prometheus.Labels{"handler": pattern}, handler))
 }
 
-func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error) {
+// ExtractLabeler is an HTTP handler that extract the label value to be
+// enforced from the HTTP request.  If a valid label value is found, it should
+// store it in the request's context.  Otherwise it should return an error in
+// the HTTP response (usually 400 or 500).
+type ExtractLabeler interface {
+	ExtractLabel(next http.HandlerFunc) http.Handler
+}
+
+// HTTPFormEnforcer enforces a label value extracted from the HTTP form and query parameters.
+type HTTPFormEnforcer struct {
+	ParameterName string
+}
+
+// ExtractLabel implements the ExtractLabeler interface.
+func (hff HTTPFormEnforcer) ExtractLabel(next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labelValue, err := hff.getLabelValue(r)
+		if err != nil {
+			prometheusAPIError(w, humanFriendlyErrorMessage(err), http.StatusBadRequest)
+			return
+		}
+
+		// Remove the proxy label from the query parameters.
+		q := r.URL.Query()
+		q.Del(hff.ParameterName)
+		r.URL.RawQuery = q.Encode()
+
+		// Remove the param from the PostForm.
+		if r.Method == http.MethodPost {
+			if err := r.ParseForm(); err != nil {
+				prometheusAPIError(w, fmt.Sprintf("Failed to parse the PostForm: %v", err), http.StatusInternalServerError)
+				return
+			}
+			if r.PostForm.Get(hff.ParameterName) != "" {
+				r.PostForm.Del(hff.ParameterName)
+				newBody := r.PostForm.Encode()
+				// We are replacing request body, close previous one (r.FormValue ensures it is read fully and not nil).
+				_ = r.Body.Close()
+				r.Body = io.NopCloser(strings.NewReader(newBody))
+				r.ContentLength = int64(len(newBody))
+			}
+		}
+
+		next.ServeHTTP(w, r.WithContext(WithLabelValue(r.Context(), labelValue)))
+	})
+}
+
+func (hff HTTPFormEnforcer) getLabelValue(r *http.Request) (string, error) {
+	formValue := r.FormValue(hff.ParameterName)
+	if formValue == "" {
+		return "", fmt.Errorf("the %q query parameter must be provided", hff.ParameterName)
+	}
+
+	return formValue, nil
+}
+
+// HTTPHeaderEnforcer enforces a label value extracted from the HTTP headers.
+type HTTPHeaderEnforcer struct {
+	Name string
+}
+
+// ExtractLabel implements the ExtractLabeler interface.
+func (hhe HTTPHeaderEnforcer) ExtractLabel(next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labelValue, err := hhe.getLabelValue(r)
+		if err != nil {
+			prometheusAPIError(w, humanFriendlyErrorMessage(err), http.StatusBadRequest)
+			return
+		}
+
+		next.ServeHTTP(w, r.WithContext(WithLabelValue(r.Context(), labelValue)))
+	})
+}
+
+func (hhe HTTPHeaderEnforcer) getLabelValue(r *http.Request) (string, error) {
+	headerValues := r.Header[hhe.Name]
+
+	if len(headerValues) == 0 {
+		return "", fmt.Errorf("missing HTTP header %q", hhe.Name)
+	}
+
+	if len(headerValues) > 1 {
+		return "", fmt.Errorf("multiple values for the http header %q", hhe.Name)
+	}
+
+	return headerValues[0], nil
+}
+
+// StaticLabelEnforcer enforces a static label value.
+type StaticLabelEnforcer string
+
+// ExtractLabel implements the ExtractLabeler interface.
+func (sle StaticLabelEnforcer) ExtractLabel(next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next(w, r.WithContext(WithLabelValue(r.Context(), string(sle))))
+	})
+}
+
+func NewRoutes(upstream *url.URL, label string, extractLabeler ExtractLabeler, opts ...Option) (*routes, error) {
 	opt := options{}
 	for _, o := range opts {
 		o.apply(&opt)
-	}
-
-	if opt.labelValue == "" && opt.headerName == "" && opt.queryParam == "" {
-		return nil, errors.New("labelValue, headerName and queryParam can't be empty.")
 	}
 
 	if opt.registerer == nil {
@@ -208,37 +275,35 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 		upstream:       upstream,
 		handler:        proxy,
 		label:          label,
-		labelValue:     opt.labelValue,
+		el:             extractLabeler,
 		errorOnReplace: opt.errorOnReplace,
-		headerName:     opt.headerName,
-		queryParam:     opt.queryParam,
 	}
 	mux := newStrictMux(newInstrumentedMux(http.NewServeMux(), opt.registerer))
 
 	errs := merrors.New(
-		mux.Handle("/federate", r.enforceLabel(enforceMethods(r.matcher, "GET"))),
-		mux.Handle("/api/v1/query", r.enforceLabel(enforceMethods(r.query, "GET", "POST"))),
-		mux.Handle("/api/v1/query_range", r.enforceLabel(enforceMethods(r.query, "GET", "POST"))),
-		mux.Handle("/api/v1/alerts", r.enforceLabel(enforceMethods(r.passthrough, "GET"))),
-		mux.Handle("/api/v1/rules", r.enforceLabel(enforceMethods(r.passthrough, "GET"))),
-		mux.Handle("/api/v1/series", r.enforceLabel(enforceMethods(r.matcher, "GET", "POST"))),
-		mux.Handle("/api/v1/query_exemplars", r.enforceLabel(enforceMethods(r.query, "GET", "POST"))),
+		mux.Handle("/federate", r.el.ExtractLabel(enforceMethods(r.matcher, "GET"))),
+		mux.Handle("/api/v1/query", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
+		mux.Handle("/api/v1/query_range", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
+		mux.Handle("/api/v1/alerts", r.el.ExtractLabel(enforceMethods(r.passthrough, "GET"))),
+		mux.Handle("/api/v1/rules", r.el.ExtractLabel(enforceMethods(r.passthrough, "GET"))),
+		mux.Handle("/api/v1/series", r.el.ExtractLabel(enforceMethods(r.matcher, "GET", "POST"))),
+		mux.Handle("/api/v1/query_exemplars", r.el.ExtractLabel(enforceMethods(r.query, "GET", "POST"))),
 	)
 
 	if opt.enableLabelAPIs {
 		errs.Add(
-			mux.Handle("/api/v1/labels", r.enforceLabel(enforceMethods(r.matcher, "GET", "POST"))),
+			mux.Handle("/api/v1/labels", r.el.ExtractLabel(enforceMethods(r.matcher, "GET", "POST"))),
 			// Full path is /api/v1/label/<label_name>/values but http mux does not support patterns.
 			// This is fine though as we don't care about name for matcher injector.
-			mux.Handle("/api/v1/label/", r.enforceLabel(enforceMethods(r.matcher, "GET"))),
+			mux.Handle("/api/v1/label/", r.el.ExtractLabel(enforceMethods(r.matcher, "GET"))),
 		)
 	}
 
 	errs.Add(
-		mux.Handle("/api/v2/silences", r.enforceLabel(enforceMethods(r.silences, "GET", "POST"))),
-		mux.Handle("/api/v2/silence/", r.enforceLabel(enforceMethods(r.deleteSilence, "DELETE"))),
-		mux.Handle("/api/v2/alerts/groups", r.enforceLabel(enforceMethods(r.enforceFilterParameter, "GET"))),
-		mux.Handle("/api/v2/alerts", r.enforceLabel(enforceMethods(r.alerts, "GET"))),
+		mux.Handle("/api/v2/silences", r.el.ExtractLabel(enforceMethods(r.silences, "GET", "POST"))),
+		mux.Handle("/api/v2/silence/", r.el.ExtractLabel(enforceMethods(r.deleteSilence, "DELETE"))),
+		mux.Handle("/api/v2/alerts/groups", r.el.ExtractLabel(enforceMethods(r.enforceFilterParameter, "GET"))),
+		mux.Handle("/api/v2/alerts", r.el.ExtractLabel(enforceMethods(r.alerts, "GET"))),
 	)
 
 	errs.Add(
@@ -281,93 +346,6 @@ func NewRoutes(upstream *url.URL, label string, opts ...Option) (*routes, error)
 	return r, nil
 }
 
-func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		lvalue, err := r.getLabelValue(req)
-		if err != nil {
-			prometheusAPIError(w, humanFriendlyErrorMessage(err), http.StatusBadRequest)
-			return
-		}
-
-		req = req.WithContext(withLabelValue(req.Context(), lvalue))
-
-		// Remove the proxy label from the query parameters.
-		q := req.URL.Query()
-		if q.Get(r.queryParam) != "" {
-			q.Del(r.queryParam)
-		}
-		req.URL.RawQuery = q.Encode()
-		// Remove the param from the PostForm.
-		if req.Method == http.MethodPost {
-			if err := req.ParseForm(); err != nil {
-				prometheusAPIError(w, fmt.Sprintf("Failed to parse the PostForm: %v", err), http.StatusInternalServerError)
-				return
-			}
-			if req.PostForm.Get(r.queryParam) != "" {
-				req.PostForm.Del(r.queryParam)
-				newBody := req.PostForm.Encode()
-				// We are replacing request body, close previous one (req.FormValue ensures it is read fully and not nil).
-				_ = req.Body.Close()
-				req.Body = io.NopCloser(strings.NewReader(newBody))
-				req.ContentLength = int64(len(newBody))
-			}
-		}
-
-		h.ServeHTTP(w, req)
-	})
-}
-
-// getLabelValue returns the statically set label value, or the label value
-// sent through a URL parameter or HTTP request header.
-// It returns an error when either the value is found in both places, or is not found at all.
-func (r *routes) getLabelValue(req *http.Request) (string, error) {
-	if r.headerName != "" {
-		headerValues, ok := req.Header[r.headerName]
-		if ok {
-			if len(headerValues) == 0 {
-				return "", fmt.Errorf("the http header %q must be provided", r.headerName)
-			} else if len(headerValues) > 1 {
-				return "", fmt.Errorf("the http header %q has multiple values", r.headerName)
-			}
-
-			if r.labelValue != "" && headerValues[0] != "" {
-				return "", fmt.Errorf("a static value for the %s label has already been specified", r.label)
-			}
-
-			if r.labelValue == "" && headerValues[0] == "" {
-				return "", fmt.Errorf("the http header %q must be provided", r.headerName)
-			}
-
-			if r.labelValue != "" {
-				return r.labelValue, nil
-			}
-
-			return headerValues[0], nil
-		}
-	} else if r.queryParam != "" {
-		formValue := req.FormValue(r.queryParam)
-		if r.labelValue != "" && formValue != "" {
-			return "", fmt.Errorf("a static value for the %s label has already been specified", r.label)
-		}
-
-		if r.labelValue == "" && formValue == "" {
-			return "", fmt.Errorf("the %q query parameter must be provided", r.queryParam)
-		}
-
-		if r.labelValue != "" {
-			return r.labelValue, nil
-		}
-
-		return formValue, nil
-	}
-
-	if r.labelValue != "" {
-		return r.labelValue, nil
-	}
-
-	return "", fmt.Errorf("options headerName and queryParam are empty")
-}
-
 func (r *routes) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.mux.ServeHTTP(w, req)
 }
@@ -397,7 +375,10 @@ type ctxKey int
 
 const keyLabel ctxKey = iota
 
-func mustLabelValue(ctx context.Context) string {
+// MustLabelValue returns a label (previously stored using WithLabelValue())
+// from the given context.
+// It will panic if no label is found or the value is empty.
+func MustLabelValue(ctx context.Context) string {
 	label, ok := ctx.Value(keyLabel).(string)
 	if !ok {
 		panic(fmt.Sprintf("can't find the %q value in the context", keyLabel))
@@ -408,7 +389,8 @@ func mustLabelValue(ctx context.Context) string {
 	return label
 }
 
-func withLabelValue(ctx context.Context, label string) context.Context {
+// WithLabelValue stores a label in the given context.
+func WithLabelValue(ctx context.Context, label string) context.Context {
 	return context.WithValue(ctx, keyLabel, label)
 }
 
@@ -421,7 +403,7 @@ func (r *routes) query(w http.ResponseWriter, req *http.Request) {
 		[]*labels.Matcher{{
 			Name:  r.label,
 			Type:  labels.MatchEqual,
-			Value: mustLabelValue(req.Context()),
+			Value: MustLabelValue(req.Context()),
 		}}...)
 
 	// The `query` can come in the URL query string and/or the POST body.
@@ -507,7 +489,7 @@ func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
 	matcher := &labels.Matcher{
 		Name:  r.label,
 		Type:  labels.MatchEqual,
-		Value: mustLabelValue(req.Context()),
+		Value: MustLabelValue(req.Context()),
 	}
 	q := req.URL.Query()
 

--- a/injectproxy/routes_test.go
+++ b/injectproxy/routes_test.go
@@ -159,57 +159,57 @@ func TestWithPassthroughPaths(t *testing.T) {
 
 	t.Run("invalid passthrough options", func(t *testing.T) {
 		// Duplicated /api.
-		_, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "/api1"}))
+		_, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/api1"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Wrong format, params in path.
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1?args=1", "/api1"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1?args=1", "/api1"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// / is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/", "/api2/something", "/api1"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/", "/api2/something", "/api1"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// "" is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "", "/api3"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate", "/api3"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/", "/api3"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// Duplication with existing enforced path is not allowed.
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/some", "/api3"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/federate/some", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4 is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "api4", "/api3"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4/ is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/", "/api3"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 		// api4/something is not valid URL path (does not start with /)
-		_, err = NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/something", "/api3"}))
+		_, err = NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "api4/something", "/api3"}))
 		if err == nil {
 			t.Fatal("expected error")
 		}
 	})
-	r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithPassthroughPaths([]string{"/api1", "/api2/something", "/graph/"}))
+	r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithPassthroughPaths([]string{"/api1", "/api2/something", "/graph/"}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestMatch(t *testing.T) {
 					),
 				)
 				defer m.Close()
-				r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithEnabledLabelsAPI())
+				r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithEnabledLabelsAPI())
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -412,7 +412,7 @@ func TestMatchWithPost(t *testing.T) {
 					),
 				)
 				defer m.Close()
-				r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel), WithEnabledLabelsAPI())
+				r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel}, WithEnabledLabelsAPI())
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -511,9 +511,8 @@ func TestSeries(t *testing.T) {
 					),
 				)
 				defer m.Close()
-				var opts []Option
-				opts = append(opts, WithQueryParam(proxyLabel))
-				r, err := NewRoutes(m.url, proxyLabel, opts...)
+
+				r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -624,10 +623,8 @@ func TestSeriesWithPost(t *testing.T) {
 					),
 				)
 				defer m.Close()
-				var opts []Option
-				opts = append(opts, WithQueryParam(proxyLabel))
 
-				r, err := NewRoutes(m.url, proxyLabel, opts...)
+				r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -856,13 +853,6 @@ func TestQuery(t *testing.T) {
 			expResponse:    okResponse,
 		},
 		{
-			name:           `Static label value with URL query parameter`,
-			staticLabelVal: "default",
-			labelv:         "other-default",
-			promQuery:      `up{instance="localhost:9090"} + foo{namespace="other"}`,
-			expCode:        http.StatusBadRequest,
-		},
-		{
 			name:         `http header label value`,
 			headers:      http.Header{"namespace": []string{"default"}},
 			headerName:   "namespace",
@@ -899,18 +889,19 @@ func TestQuery(t *testing.T) {
 				if tc.errorOnReplace {
 					opts = append(opts, WithErrorOnReplace())
 				}
+
+				var labelEnforcer ExtractLabeler
 				if tc.staticLabelVal != "" {
-					opts = append(opts, WithLabelValue(tc.staticLabelVal))
-				}
-				if tc.headerName != "" {
-					opts = append(opts, WithHeaderName(tc.headerName))
+					labelEnforcer = StaticLabelEnforcer(tc.staticLabelVal)
+				} else if tc.headerName != "" {
+					labelEnforcer = HTTPHeaderEnforcer{Name: tc.headerName}
 				} else if tc.queryParam != "" {
-					opts = append(opts, WithQueryParam(tc.queryParam))
+					labelEnforcer = HTTPFormEnforcer{ParameterName: tc.queryParam}
 				} else {
-					opts = append(opts, WithQueryParam(proxyLabel))
+					labelEnforcer = HTTPFormEnforcer{ParameterName: proxyLabel}
 				}
 
-				r, err := NewRoutes(m.url, proxyLabel, opts...)
+				r, err := NewRoutes(m.url, proxyLabel, labelEnforcer, opts...)
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
 				}
@@ -923,7 +914,7 @@ func TestQuery(t *testing.T) {
 				q.Set(queryParam, tc.promQuery)
 				if tc.queryParam != "" && tc.labelv != "" {
 					q.Set(tc.queryParam, tc.labelv)
-				} else if tc.labelv != "" {
+				} else if tc.staticLabelVal == "" && tc.headerName == "" && tc.labelv != "" {
 					q.Set(proxyLabel, tc.labelv)
 				}
 				u.RawQuery = q.Encode()

--- a/injectproxy/rules.go
+++ b/injectproxy/rules.go
@@ -175,7 +175,7 @@ func modifyAPIResponse(f func(string, *apiResponse) (interface{}, error)) func(*
 			return errors.Wrap(err, "can't decode API response")
 		}
 
-		v, err := f(mustLabelValue(resp.Request.Context()), apir)
+		v, err := f(MustLabelValue(resp.Request.Context()), apir)
 		if err != nil {
 			return err
 		}

--- a/injectproxy/rules_test.go
+++ b/injectproxy/rules_test.go
@@ -658,7 +658,7 @@ func TestRules(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel))
+			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -837,7 +837,7 @@ func TestAlerts(t *testing.T) {
 		t.Run(fmt.Sprintf("%s=%s", proxyLabel, tc.labelv), func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel))
+			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/injectproxy/silences.go
+++ b/injectproxy/silences.go
@@ -49,7 +49,7 @@ func (r *routes) enforceFilterParameter(w http.ResponseWriter, req *http.Request
 		proxyLabelMatch = labels.Matcher{
 			Type:  labels.MatchEqual,
 			Name:  r.label,
-			Value: mustLabelValue(req.Context()),
+			Value: MustLabelValue(req.Context()),
 		}
 		modified = []string{proxyLabelMatch.String()}
 	)
@@ -75,7 +75,7 @@ func (r *routes) enforceFilterParameter(w http.ResponseWriter, req *http.Request
 func (r *routes) postSilence(w http.ResponseWriter, req *http.Request) {
 	var (
 		sil    models.PostableSilence
-		lvalue = mustLabelValue(req.Context())
+		lvalue = MustLabelValue(req.Context())
 	)
 	if err := json.NewDecoder(req.Body).Decode(&sil); err != nil {
 		prometheusAPIError(w, fmt.Sprintf("bad request: can't decode: %v", err), http.StatusBadRequest)
@@ -143,7 +143,7 @@ func (r *routes) deleteSilence(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !hasMatcherForLabel(sil.Matchers, r.label, mustLabelValue(req.Context())) {
+	if !hasMatcherForLabel(sil.Matchers, r.label, MustLabelValue(req.Context())) {
 		prometheusAPIError(w, "forbidden", http.StatusForbidden)
 		return
 	}

--- a/injectproxy/silences_test.go
+++ b/injectproxy/silences_test.go
@@ -73,7 +73,7 @@ func TestListSilences(t *testing.T) {
 		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", "filter", tc.expFilters...))
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel))
+			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -300,7 +300,7 @@ func TestDeleteSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel))
+			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -495,7 +495,7 @@ func TestUpdateSilence(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			m := newMockUpstream(tc.upstream)
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel))
+			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -566,7 +566,7 @@ func TestGetAlertGroups(t *testing.T) {
 		t.Run(strings.Join(tc.filters, "&"), func(t *testing.T) {
 			m := newMockUpstream(checkQueryHandler("", tc.queryParam, tc.expQueryValues...))
 			defer m.Close()
-			r, err := NewRoutes(m.url, proxyLabel, WithQueryParam(proxyLabel))
+			r, err := NewRoutes(m.url, proxyLabel, HTTPFormEnforcer{ParameterName: proxyLabel})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
The interface abstracts how the label value is extracted from the incoming request. Currently 3 implementations are provided:
1. Get the value from the HTTP form/query parameters.
2. Get the value from the HTTP headers.
3. Get a static value.

@jkroepke thanks a lot for your work! I think that this new feature requires some refactoring to simplify the existing codebase. I've outlined my suggestions in this PR, feel free to comment and criticize :) 